### PR TITLE
Add http2 support to cloudfront

### DIFF
--- a/blog/setup-s3-cloudfront-cdn.md
+++ b/blog/setup-s3-cloudfront-cdn.md
@@ -221,7 +221,7 @@ Resources:
               IncludeBody: false
         DefaultRootObject: 'index.html'
         Enabled: true
-        HttpVersion: 'http1.1'
+        HttpVersion: 'http2'
         IPV6Enabled: false
         Origins:
           - DomainName: !GetAtt S3Bucket.DomainName

--- a/cloudformation/s3bucket_with_cloudfront.yaml
+++ b/cloudformation/s3bucket_with_cloudfront.yaml
@@ -142,7 +142,7 @@ Resources:
               IncludeBody: false
         DefaultRootObject: 'index.html'
         Enabled: true
-        HttpVersion: 'http1.1'
+        HttpVersion: 'http2'
         IPV6Enabled: false
         Origins:
           - DomainName: !GetAtt S3Bucket.DomainName


### PR DESCRIPTION
Fixes #31

Dokku app already serves http/2.

Check the following

- [ ] If a markdown file has been renamed then redirects have been added in `next.config.js`
