### PR TITLE
Improve deployment approach & add staging deploys

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,10 +1,10 @@
-name: Publish
+name: Prod deploy
 on:
   release:
     types: [published]
 
 jobs:
-  publish-docker:
+  publish-docker-image:
     name: Publish docker image
     runs-on: ubuntu-20.04
     steps:
@@ -33,14 +33,15 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64
-          tags: ghcr.io/${{ github.repository_owner }}/${{ secrets.DOKKU_APP_NAME }}:latest
+          tags: ghcr.io/${{ github.repository_owner }}/richardwillis:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           build-args: |
             APP_VERSION=${{ github.event.release.tag_name }}
+
   publish-s3:
-    name: Publish to S3
-    needs: [publish-docker]
+    name: Publish static assets to S3
+    needs: [publish-docker-image]
     runs-on: ubuntu-20.04
     steps:
       - name: Login to GitHub Container Registry
@@ -51,8 +52,8 @@ jobs:
           password: ${{ secrets.CR_PAT }}
       - name: Copy static files from docker image
         run: |
-          docker pull ghcr.io/${{ github.repository_owner }}/${{ secrets.DOKKU_APP_NAME }}:latest
-          docker run -i --name helper ghcr.io/${{ github.repository_owner }}/${{ secrets.DOKKU_APP_NAME }}:latest true
+          docker pull ghcr.io/${{ github.repository_owner }}/richardwillis:latest
+          docker run -i --name helper ghcr.io/${{ github.repository_owner }}/richardwillis:latest true
           docker cp helper:/app/.next .
           docker rm helper
       - name: Sync static assets to S3
@@ -63,25 +64,33 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'eu-west-2'
+          AWS_REGION: 'us-east-1'
           SOURCE_DIR: '.next/static'
           DEST_DIR: '_next/static'
+
   deploy:
     name: Deploy app
-    needs: [publish-docker, publish-s3]
+    needs: [publish-s3]
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up SSH
+      - name: Create deploy repo
+        id: deploy_repo
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DOKKU_SSH_PRIVATE_KEY }}" | tr -d '\r' > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan ${{ secrets.DOKKU_HOST }} >> ~/.ssh/known_hosts
-      - name: Deploy app
-        run: |
-          ssh root@${{ secrets.DOKKU_HOST }} "\\
-            docker pull ghcr.io/${{ github.repository_owner }}/${{ secrets.DOKKU_APP_NAME }}:latest && \\
-            docker tag ghcr.io/${{ github.repository_owner }}/${{ secrets.DOKKU_APP_NAME }}:latest dokku/${{ secrets.DOKKU_APP_NAME }}:latest && \\
-            dokku config:set --no-restart ${{ secrets.DOKKU_APP_NAME }} APP_VERSION=\"${{ github.event.release.tag_name }}\" && \\
-            dokku tags:deploy ${{ secrets.DOKKU_APP_NAME }} latest && \\
-            dokku cleanup"
+          echo "FROM $IMAGE_URL" > Dockerfile
+          git init
+          git config user.email "willis.rh@gmail.com"
+          git config user.name "Richard Willis"
+          git add Dockerfile
+          git commit -m "Add Dockerfile"
+          commit=$(git rev-parse HEAD 2>/dev/null || true)
+          echo ::set-output name=commit_sha::$commit
+        env:
+          IMAGE_URL: ghcr.io/${{ github.repository_owner }}/richardwillis:latest
+      - name: Push to dokku
+        uses: dokku/github-action@master
+        with:
+          command: deploy
+          git_remote_url: ${{ secrets.GIT_REMOTE_URL }}
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          git_push_flags: '--force'
+          ci_commit: ${{ steps.deploy_repo.outputs.commit_sha }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,77 @@
+name: Staging deploy
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    branches: [master]
+
+jobs:
+  publish-staging-docker-image:
+    if: contains(github.event.pull_request.labels.*.name, 'staging')
+    name: Publish staging docker image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build and push docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ghcr.io/${{ github.repository_owner }}/richardwillis:staging
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          build-args: |
+            APP_VERSION=staging-${{github.event.number}}
+            ASSET_PREFIX=/
+
+  deploy-staging-app:
+    needs: [publish-staging-docker-image]
+    if: contains(github.event.pull_request.labels.*.name, 'staging')
+    name: Deploy staging app
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Create deploy repo for dokku
+        id: deploy_repo
+        run: |
+          echo "FROM $IMAGE_URL" > Dockerfile
+          git init
+          git config user.email "willis.rh@gmail.com"
+          git config user.name "Richard Willis"
+          git add Dockerfile
+          git commit -m "Add Dockerfile"
+          commit=$(git rev-parse HEAD 2>/dev/null || true)
+          echo ::set-output name=commit_sha::$commit
+        env:
+          IMAGE_URL: ghcr.io/${{ github.repository_owner }}/richardwillis:staging
+      - name: Push to dokku
+        uses: dokku/github-action@master
+        with:
+          command: 'review-apps:create'
+          review_app_name: 'staging-richardwillis'
+          git_remote_url: ${{ secrets.GIT_REMOTE_URL }}
+          ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          git_push_flags: '--force'
+          ci_commit: ${{ steps.deploy_repo.outputs.commit_sha }}
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.number }}
+          body: 'Staging app successfully deployed to http://staging-richardwillis.${{ secrets.DOKKU_HOST }}'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,9 @@
   "files.trimTrailingWhitespace": true,
   "cSpell.language": "en-GB",
   "tailwindCSS.colorDecorators": "off",
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-workflow": ".github/workflows/*.yml"
+  },
   "cSpell.words": [
     "Buildx",
     "Contentful",

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=builder --chown=node:node $APP_HOME/public $APP_HOME/public
 COPY --from=builder --chown=node:node $APP_HOME/build $APP_HOME/build
 COPY --from=builder --chown=node:node $APP_HOME/app.json $APP_HOME/app.json
 
-EXPOSE $PORT
+EXPOSE 3000
 
 USER node
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ First build & push the docker image:
 ```bash
 echo $CR_PAT | docker login ghcr.io -u badsyntax --password-stdin
 docker build -t ghcr.io/badsyntax/richardwillis:latest --build-arg ASSET_PREFIX=/ .
+docker run --publish 3000:3000 ghcr.io/badsyntax/richardwillis:latest
 docker push ghcr.io/badsyntax/richardwillis:latest
 ```
 
@@ -117,3 +118,23 @@ dokku domains:add staticman staticman.richardwillis.info
 dokku tags:deploy staticman latest
 dokku letsencrypt staticman
 ```
+
+## Github actions
+
+- AWS_ACCESS_KEY_ID
+- AWS_S3_BUCKET
+- AWS_SECRET_ACCESS_KEY
+- CR_PAT
+- DOKKU_HOST (eg dokku.example.com)
+- DOKKU_SSH_PRIVATE_KEY
+- GIT_REMOTE_URL (eg ssh://dokku@dokku.me:22/appname);
+- RELEASE_DRAFTER_TOKEN_GITHUB
+
+### Providing a SSH key
+
+```bash
+ssh-keygen -N "" -f ~/.ssh/dokkugithubactions
+cat ~/.ssh/dokkugithubactions.pub | ssh root@dokku.me dokku ssh-keys:add GITHUB_ACTIONS
+```
+
+Now provide the contents of `~/.ssh/dokkugithubactions` as `DOKKU_SSH_PRIVATE_KEY`

--- a/blog/deploy-dokku-app-remote-docker-image.md
+++ b/blog/deploy-dokku-app-remote-docker-image.md
@@ -1,0 +1,217 @@
+---
+title: 'Deploy a dokku App With a Remote Docker Image'
+excerpt: 'How to deploy your app using a remote dokku image.'
+date: '2021-01-06T05:35:07.322Z'
+author:
+  name: Richard Willis
+  picture: '/assets/blog/authors/richard.jpg'
+ogImage:
+  url: '/assets/blog/hello-world/cover.jpg'
+draft: false
+---
+
+There's a couple ways to deploy your app to dokku. The most common workflow being the heroku style `git push`. This approach is convenient, but means app builds take place on your server. This is perhaps not a problem for most people, but was quite a big problem for me as I'm deploying apps with complicated builds (using webpack) that take long time to complete and require a lot of machine resources (like a LOT of RAM and a decent amount of processing power). These builds ultimately kill my runtime server and my running apps are unresponsive while a build is taking place. Sure, I could throw more RAM and CPU at the problem, but I'm still on a budget and conceptually I don't like the idea of builds taking place on my runtime server.
+
+## Deploy a pre-built App
+
+To prevent building your app on your server you can build it locally and deploy it using the remote image. Unfortunately this breaks the `git push` workflow, but more on that below...
+
+### Deploy Using a Remote Docker Image
+
+This approach involves:
+
+- Building your image locally
+- Pushing it to a remote registry
+- Log into your server and pull the image from the registry
+- Tag the image and deploy using dokku commands
+
+Here's the commands to achieve this:
+
+```bash
+# on your local machine
+echo $CR_PAT | docker login ghcr.io -u user --password-stdin
+docker build -t ghcr.io/user/app:latest .
+docker push ghcr.io/use/app:latest
+
+# on your dokku server
+dokku apps:create app
+echo $CR_PAT | docker login ghcr.io -u user --password-stdin
+docker pull ghcr.io/user/app:latest
+docker tag ghcr.io/user/app:latest dokku/app:latest
+dokku tags:deploy app latest
+```
+
+If you want to automate this in CI (using GitHub Actions):
+
+```yaml
+name: Publish
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-docker:
+    name: Publish docker image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build and push docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ghcr.io/${{ github.repository }}:latest
+  deploy:
+    name: Deploy app
+    needs: [publish-docker]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DOKKU_SSH_PRIVATE_KEY }}" | tr -d '\r' > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan ${{ secrets.DOKKU_HOST }} >> ~/.ssh/known_hosts
+      - name: Deploy app
+        run: |
+          ssh root@${{ secrets.DOKKU_HOST }} "\\
+            docker pull ghcr.io/${{ github.repository }}:latest && \\
+            docker tag ghcr.io/${{ github.repository }}:latest dokku/app:latest && \\
+            dokku tags:deploy app latest"
+```
+
+You'll note we're using the `root` user to pull & tag the docker image. _This is far from ideal._ I'd prefer to use the `dokku` user, but as that user is using `sshcommand` (which sets the default command to be `dokku`), you can't use the dokku user to achieve this.
+
+I don't like this. I want dokku to handle this for me. I created a [GitHub issue](https://github.com/dokku/dokku/issues/4296) and it looks like the dokku maintainers will support this workflow in the future.
+
+### Deploy Using a Remote Docker Image With `git push`
+
+Until dokku supports [remote image deployments with git](https://github.com/dokku/dokku/issues/4296), there is a hacky workaround we can use. This approach is not practical for local deployments but can be used in CI.
+
+Let's use a basic `Dockerfile` as an example:
+
+```dockerfile
+FROM node:12.19.0 as build
+
+WORKDIR /app
+
+COPY ./package.json /app/package.json
+COPY ./package-lock.json /app/package-lock.json
+
+RUN npm ci
+COPY . .
+RUN npm run build
+
+
+FROM nginx
+
+COPY ./nginx /etc/nginx
+COPY --from=build /app/build /usr/share/nginx/html
+```
+
+This `Dockerfile` shows an example of a complicated build (building a front-end app using webpack etc). Notice the build stages referencing base images (`FROM node:12.19.0` and `FROM nginx`). We can utilise build stages and base images to deploy our pre-built app. All we need to do is build and push the docker image, then create a new Dockerfile that references that remote image as a build image.
+
+For example:
+
+```dockerfile
+FROM ghcr.io/user/app:latest
+```
+
+If we now add this Dockerfile to the root of our application and `git push`, then docker simply pulls the base image and dokku deploys it. _No builds take place on the server._
+
+As previously mentioned, this is not practical to do locally, but we can achieve this quite easily in CI (using GitHub Actions):
+
+```yaml
+name: Deploy
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-docker:
+    name: Publish docker image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build and push docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ghcr.io/${{ github.repository }}:latest
+
+  deploy-app:
+    needs: [publish-docker]
+    name: Deploy app
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Create deploy repo for dokku
+        id: deploy_repo
+        run: |
+          echo "FROM $IMAGE_URL" > Dockerfile
+          git init
+          git config user.email "user@email.com"
+          git config user.name "Your Name"
+          git add Dockerfile
+          git commit -m "Add Dockerfile"
+          commit=$(git rev-parse HEAD 2>/dev/null || true)
+          echo ::set-output name=commit_sha::$commit
+        env:
+          IMAGE_URL: ghcr.io/${{ github.repository_owner }}/app:latest
+      - name: Push to dokku
+        uses: dokku/github-action@master
+        with:
+          command: deploy
+          git_remote_url: 'ssh://dokku@dokku.me:22/appname'
+          ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          git_push_flags: '--force'
+          ci_commit: ${{ steps.deploy_repo.outputs.commit_sha }}
+```
+
+You'll note we're creating a fresh git repo to achieve this.
+
+#### Using a Moving Tag
+
+This example uses a moving tag `latest`. While I generally try to avoid using a moving tag, I'm doing this as I have concerns over storage quotas using GitHub Container Registry.
+
+_If you use a moving tag, you need to tell docker to not use cache and to pull the base image when building your app._ If you don't do this, each time you deploy docker will use the previous cached version of `ghcr.io/user/app:latest`. You can set the correct no-cache build args like so:
+
+```bash
+dokku docker-options:add app build "--no-cache --pull"
+```
+
+Now every-time you deploy, docker will pull down the latest version of the moving tag.
+
+## Conclusion
+
+While the workaround is hacky, it provides the following benefits:
+
+- We're using a supported dokku workflow (`git push`)
+- We don't need to use a different Linux user to achieve this
+- It allows us to the use the official dokku [GitHub Action](https://github.com/dokku/github-action) (which provides some awesome features like app previews)
+
+Once support for [remote image deployments with git](https://github.com/dokku/dokku/issues/4296) lands we can remove this hacky workaround. Until then, this works for me!

--- a/blog/self-hosted-staticman-dokku-nextjs.md
+++ b/blog/self-hosted-staticman-dokku-nextjs.md
@@ -88,7 +88,7 @@ ENV NODE_ENV production
 
 COPY --from=builder --chown=node:node /app /app
 
-EXPOSE $PORT
+EXPOSE 3000
 
 USER node
 

--- a/src/features/about/AboutPage/AboutPage.tsx
+++ b/src/features/about/AboutPage/AboutPage.tsx
@@ -27,6 +27,12 @@ export const AboutPage: React.FunctionComponent = () => {
           <Link href="/projects">open-source projects</Link>).
         </p>
         <p>
+          As you can probably tell I like minimal design. I also strongly
+          believe speed plays a huge part in the usablity and user experience of
+          a product, and I put in a fair bit of effort to make this site fast
+          &amp; responsive.
+        </p>
+        <p>
           When not coding I enjoy being outdoors and love hiking and cycling.
           Sometimes I do a bit of indoor bouldering too. I grew up in South
           Africa before moving to London, then Barcelona. I recently moved back

--- a/src/features/blog/api.ts
+++ b/src/features/blog/api.ts
@@ -31,7 +31,7 @@ export function getComments(slug: string): PostComment[] {
   function parseComment(fileName: string): PostComment | null {
     const filePath = join(rootDir, fileName);
     try {
-      const comment = yaml.safeLoad(
+      const comment = yaml.load(
         fs.readFileSync(filePath, 'utf8')
       ) as PostComment;
       return {

--- a/src/features/layout/Typography/Typography.module.css
+++ b/src/features/layout/Typography/Typography.module.css
@@ -62,3 +62,15 @@
 .variant-prose :global(code[class*='language-']) {
   @apply text-xs sm:text-base;
 }
+
+.variant-prose :global(blockquote) {
+  @apply font-normal;
+}
+
+.variant-prose :global(blockquote) :global(p:first-of-type::before) {
+  content: no-open-quote;
+}
+
+.variant-prose :global(blockquote) :global(p:first-of-type::after) {
+  content: no-close-quote;
+}

--- a/staticman/Dockerfile
+++ b/staticman/Dockerfile
@@ -32,7 +32,7 @@ ENV PORT 3000
 
 COPY --from=builder --chown=node:node /app /app
 
-EXPOSE $PORT
+EXPOSE 3000
 
 USER node
 


### PR DESCRIPTION
I initially wanted review apps for each PR but have concerns on the GitHub Container Registry limits, so now there's only the concept of 1 staging deploy. 

Staging deploys happen when you add the `staging` label to a PR.

This change also removes the requirement to ssh into the dokku server as root. 