### PR TITLE
Upgrade to Staticman v3

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -42,10 +42,12 @@ module.exports = {
     isProd
       ? {
           staticManRepo: 'badsyntax/richardwillis.info',
+          staticManGitProvider: 'github',
           staticManEndpoint: 'https://staticman.richardwillis.info',
         }
       : {
           staticManRepo: 'badsyntax/richardwillis.info',
+          staticManGitProvider: 'github',
           staticManEndpoint: 'http://localhost:3002',
         }
   ),

--- a/src/features/apiClient/apiClient.ts
+++ b/src/features/apiClient/apiClient.ts
@@ -1,7 +1,7 @@
 import getConfig from 'next/config';
 import { Repo } from '../../types/types';
 
-const { staticManEndpoint, staticManRepo } = getConfig().publicRuntimeConfig;
+const { staticManEndpoint, staticManGitProvider, staticManRepo } = getConfig().publicRuntimeConfig;
 
 async function makeRequest(
   url: string,
@@ -15,7 +15,7 @@ async function makeRequest(
 }
 
 export function postComment(comment: FormData): Promise<Response> {
-  const url = `${staticManEndpoint}/v2/entry/${staticManRepo}/master/comments`;
+  const url = `${staticManEndpoint}/v3/entry/${staticManGitProvider}/${staticManRepo}/master/comments`;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const searchParams = new URLSearchParams(comment);


### PR DESCRIPTION
# Motivation

The updated official docs recommends using GitHub Apps authorization mechanism: https://staticman.net/docs/getting-started.html.
By making use of a private GitHub App instead of a GitHub bot, others can't use it.

# Goal

To resolve wetty/www.wetterer.de#6.

# Description

- introduce a site config parameter called `staticmanGitProvider`
- update the POST URL according to the official docs

:information_source: Unless either one of the following actions is taken, this PR won't work.

1. GitHub bot: add the route `/v3/connect` by merging the pending PR eduardoboucas/staticman<span>#</spna>405
2. GitHub app (recommended): see the updated docs and/or my illustrated guide: https://github.com/pacollins/hugo-future-imperfect-slim/wiki/staticman.yml